### PR TITLE
Small fixes to make press and click work as expected

### DIFF
--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -604,7 +604,7 @@ def click(*args):
         button = MB.parse(args[0])
     elif argc == 2:
         x, y = args
-        button = MB.parse(args[0])
+        button = MB.L
         # TODO move mouse with the call directly
         move(x, y)
     elif argc == 3:

--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -307,7 +307,7 @@ GMEM_ZEROINIT = 0x0040
 
 
 def _key_to_vk(key):
-    key = key.strip().upper()
+    key = key.strip(' ').upper()
     try:
         return KEY_MAP[key]
     except KeyError:


### PR DESCRIPTION
Fixes for two current issues:
* currently press('\t') and press('\n') are not working because these key descriptions get removed as white space
* currently click(x,y) does create a left mouse click