### PR TITLE
make press(' ') work

### DIFF
--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -307,10 +307,10 @@ GMEM_ZEROINIT = 0x0040
 
 
 def _key_to_vk(key):
-	if set(key) == {' '}: # only spaces?
-		key = ' '
-	else:
-		key = key.strip(' ').upper()
+    if set(key) == {' '}: # only spaces?
+        key = ' '
+    else:
+        key = key.strip(' ').upper()
     try:
         return KEY_MAP[key]
     except KeyError:

--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -307,9 +307,7 @@ GMEM_ZEROINIT = 0x0040
 
 
 def _key_to_vk(key):
-    if set(key) == {' '}: # only spaces?
-        key = ' '
-    else:
+    if key != ' ':
         key = key.strip(' ').upper()
     try:
         return KEY_MAP[key]

--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -604,7 +604,7 @@ def click(*args):
         button = MB.parse(args[0])
     elif argc == 2:
         x, y = args
-        button = MB.parse(args[0])
+        button = MB.L
         # TODO move mouse with the call directly
         move(x, y)
     elif argc == 3:

--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -307,7 +307,10 @@ GMEM_ZEROINIT = 0x0040
 
 
 def _key_to_vk(key):
-    key = key.strip(' ').upper()
+	if set(key) == {' '}: # only spaces?
+		key = ' '
+	else:
+		key = key.strip(' ').upper()
     try:
         return KEY_MAP[key]
     except KeyError:

--- a/ait/_windows.py
+++ b/ait/_windows.py
@@ -307,7 +307,7 @@ GMEM_ZEROINIT = 0x0040
 
 
 def _key_to_vk(key):
-    key = key.strip().upper()
+    key = key.strip(' ').upper()
     try:
         return KEY_MAP[key]
     except KeyError:


### PR DESCRIPTION
With the previous commit only `press('\t')` and `press('\n')` were fixed, now also `press(' ')` works.